### PR TITLE
add absolute file path to files array

### DIFF
--- a/server/models/file-system.js
+++ b/server/models/file-system.js
@@ -21,6 +21,7 @@ module.exports = function(FileSystem) {
   );
 
   FileSystem.readdir = function(p, callback) {
+		p = path.resolve(p);
     fs.readdir(p, function(err, files) {
       if (err) return callback(err);
 

--- a/server/models/file-system.js
+++ b/server/models/file-system.js
@@ -21,7 +21,7 @@ module.exports = function(FileSystem) {
   );
 
   FileSystem.readdir = function(p, callback) {
-		p = path.resolve(p);
+    p = path.resolve(p);
     fs.readdir(p, function(err, files) {
       if (err) return callback(err);
 


### PR DESCRIPTION
return absolute path when relative `{ path: '.' }` is given in initial call.
