### PR TITLE
deps: upgrade tap to avoid dead request

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "eslint --ignore-path .gitignore .",
     "test": "tap --bail --coverage --coverage-report=cobertura --timeout=200 test/test-*.*",
-    "posttest": "nyc report --reporter=lcov && nyc report"
+    "posttest": "tap --coverage-report=lcov && tap --coverage-report=text"
   },
   "dependencies": {
     "async": "^1.5.0",
@@ -23,9 +23,8 @@
     "eslint-config-strongloop": "^1.x",
     "jshint": "^2.5.6",
     "loopback-explorer": "^1.1.0",
-    "nyc": "^3.x",
     "supertest": "^1.1.0",
-    "tap": "^2.3.1"
+    "tap": "^6.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
tap prior to v6 pulls in a deep dependency on request@2.69.1, which does not exist.
